### PR TITLE
Fix ByteBuffer to String Conversion Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For integer and double values a minimum and maximum value are also required.
    Supplier<Double> doubleValue = builder.define( "doubleValue", 0.5, 0, 1);
 
    Supplier<ExampleEnum> enumValue = builder.define( "enumValue", ExampleEnum.VALUE_1 );
+
+   Supplier<String> stringValue = builder.define( "stringValue", "exampleValue", 1, 20 );
 ```
 A comment can be added to a value by calling `ModConfigBuilder#comment(String)` before defining the value.
 ```java

--- a/src/main/java/com/supermartijn642/configlib/json/JsonStringConfigEntry.java
+++ b/src/main/java/com/supermartijn642/configlib/json/JsonStringConfigEntry.java
@@ -52,6 +52,7 @@ public class JsonStringConfigEntry extends BaseConfigEntry<String,JsonElement> {
         if(length > this.maxLength)
             return null;
         byte[] bytes = new byte[length];
+        buffer.get(bytes);  // Read the bytes from the buffer into the byte array
         return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/supermartijn642/configlib/toml/TomlStringConfigEntry.java
+++ b/src/main/java/com/supermartijn642/configlib/toml/TomlStringConfigEntry.java
@@ -50,6 +50,7 @@ public class TomlStringConfigEntry extends BaseConfigEntry<String,TomlElement> {
         if(length > this.maxLength)
             return null;
         byte[] bytes = new byte[length];
+        buffer.get(bytes);  // Read the bytes from the buffer into the byte array
         return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/com/supermartijn642/configlib/example/ExampleModConfig.java
+++ b/src/test/java/com/supermartijn642/configlib/example/ExampleModConfig.java
@@ -18,6 +18,7 @@ public class ExampleModConfig {
     public static final Supplier<Integer> integerValue;
     public static final Supplier<Double> doubleValue;
     public static final Supplier<ExampleEnum> enumValue;
+    public static final Supplier<String> stringValue;
 
     public static final Supplier<Boolean> notReloadedValue;
     public static final Supplier<Boolean> notSynchronizedValue;
@@ -37,7 +38,8 @@ public class ExampleModConfig {
         doubleValue = builder.comment("this is a double value between 0.0 and 1.0").define("doubleValue", 0.5, 0, 1);
         // an enum value
         enumValue = builder.comment("this is an enum value of type ExampleEnum").define("enumValue", ExampleEnum.DOGS);
-
+        // a string value
+        stringValue = builder.comment("this is a string value with min length 1 and max length 20").define("stringValue", "defaultValue", 1, 20);
 
         // values are reloaded between world loads by default, to only load a value at launch use ModConfigBuilder#gameRestart()
         notReloadedValue = builder.gameRestart().comment("this value is only reloaded when Minecraft launches").define("notReloadedValue", true);


### PR DESCRIPTION
Hi, I was using your Lib when I stumbled across an issue where my String config values always returned the correct number of bytes but containing null.

This pull request addresses a bug in the `read(ByteBuffer buffer)` methods from the `Json-` and `TomlStringConfigEntry` where the conversion of a `ByteBuffer` to a `String` resulted in a string of null characters. The issue was caused by not correctly reading the bytes from the `ByteBuffer` into the `byte` array before converting it to a String.

**Changes:**
Updated the `read(ByteBuffer buffer)` method to include a `buffer.get(bytes)` call that reads the bytes from the ByteBuffer into the byte array.